### PR TITLE
Fix ArrayIndexOutOfBoundsException

### DIFF
--- a/ui/src/main/java/ru/tinkoff/acquiring/sdk/adapters/CardsViewPagerAdapter.kt
+++ b/ui/src/main/java/ru/tinkoff/acquiring/sdk/adapters/CardsViewPagerAdapter.kt
@@ -133,7 +133,12 @@ internal class CardsViewPagerAdapter(
                 }
                 enterCardView = editCard
 
-                val viewState = detachedViews?.get(detachedViews?.keyAt(0) ?: 0)
+                val viewState = if (detachedViews!!.size() > 0) {
+                    detachedViews?.get(detachedViews?.keyAt(0) ?: 0)
+                } else {
+                    null
+                }
+
                 if (viewState != null) {
                     inflatedView.restoreHierarchyState(viewState)
                 }


### PR DESCRIPTION
When starting a payment, a crash occurred while trying to take an item from an empty list.