### PR TITLE
EditCard animation fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## 2.4.2
+
+#### Fixed
+Fixed a problem during payment when trying to enter new card credentials on device with animations
+scale set to zero
+on device
+#### Changes
+#### Additions
+
 ## 2.4.1
 
 #### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.4.1
+VERSION_NAME=2.4.2
 VERSION_CODE=15
 GROUP=ru.tinkoff.acquiring
 


### PR DESCRIPTION
Fixed a problem during payment when trying to enter new card credentials on device with animations scale set to zero